### PR TITLE
Set api versions to 120/102

### DIFF
--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -37,7 +37,7 @@ module Chef::Provisioning
       @oneview_password    = config[:knife][:oneview_password]
       fail 'Must set the knife[:oneview_password] attribute!' if @oneview_password.nil? || @oneview_password.empty?
       @oneview_disable_ssl = config[:knife][:oneview_ignore_ssl]
-      @oneview_api_version = get_oneview_api_version
+      @oneview_api_version = 120 # get_oneview_api_version
       @oneview_key         = login_to_oneview
 
       @icsp_base_url       = config[:knife][:icsp_url]
@@ -47,7 +47,7 @@ module Chef::Provisioning
       @icsp_password       = config[:knife][:icsp_password]
       fail 'Must set the knife[:icsp_password] attribute!' if @icsp_password.nil? || @icsp_password.empty?
       @icsp_disable_ssl    = config[:knife][:icsp_ignore_ssl]
-      @icsp_api_version    = get_icsp_api_version
+      @icsp_api_version    = 102 # get_icsp_api_version
       @icsp_key            = login_to_icsp
     end
 
@@ -109,10 +109,8 @@ module Chef::Provisioning
     end
 
 
-    def stop_machine(action_handler, machine_spec, machine_options)
-      if machine_spec.reference
-        power_off(action_handler, machine_spec)
-      end
+    def stop_machine(action_handler, machine_spec, _machine_options)
+      power_off(action_handler, machine_spec) if machine_spec.reference
     end
 
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,8 +7,8 @@ require 'webmock/rspec'
 
 RSpec.configure do |config|
   config.before(:each) do
-    allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:get_oneview_api_version).and_return('1.20')
-    allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:get_icsp_api_version).and_return('120')
+    allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:get_oneview_api_version).and_return(120)
+    allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:get_icsp_api_version).and_return(102)
     allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:login_to_oneview).and_return('long_oneview_key')
     allow_any_instance_of(Chef::Provisioning::OneViewDriver).to receive(:login_to_icsp).and_return('long_icsp_key')
 

--- a/spec/unit/oneview_driver_spec.rb
+++ b/spec/unit/oneview_driver_spec.rb
@@ -84,14 +84,14 @@ RSpec.describe Chef::Provisioning::OneViewDriver do
       expect(@instance.instance_variable_get('@oneview_username')).to eq('Administrator')
       expect(@instance.instance_variable_get('@oneview_password')).to eq('password12')
       expect(@instance.instance_variable_get('@oneview_disable_ssl')).to eq(true)
-      expect(@instance.instance_variable_get('@oneview_api_version')).to eq('1.20')
+      expect(@instance.instance_variable_get('@oneview_api_version')).to eq(120)
       expect(@instance.instance_variable_get('@oneview_key')).to eq('long_oneview_key')
 
       expect(@instance.instance_variable_get('@icsp_base_url')).to eq('https://my-icsp.my-domain.com')
       expect(@instance.instance_variable_get('@icsp_username')).to eq('administrator')
       expect(@instance.instance_variable_get('@icsp_password')).to eq('password123')
       expect(@instance.instance_variable_get('@icsp_disable_ssl')).to eq(nil)
-      expect(@instance.instance_variable_get('@icsp_api_version')).to eq('120')
+      expect(@instance.instance_variable_get('@icsp_api_version')).to eq(102)
       expect(@instance.instance_variable_get('@icsp_key')).to eq('long_icsp_key')
     end
   end


### PR DESCRIPTION
Sets the api version for OneView requests to 120, and ICsp to 102. Allows different versions to keep compatibility
