### PR TITLE
Ssh key

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,6 @@
 # See default at https://github.com/bbatsov/rubocop/blob/master/config/default.yml
 
+
 # Common configuration.
 AllCops:
   Exclude:
@@ -90,5 +91,8 @@ Metrics/ModuleLength:
   Enabled: false
 
 Style/SpaceAroundOperators:
+  Enabled: false
+
+Style/ExtraSpacing:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -85,3 +85,10 @@ Style/RescueModifier:
 
 Style/SpaceInsideBlockBraces:
   Enabled: false
+
+Metrics/ModuleLength:
+  Enabled: false
+
+Style/SpaceAroundOperators:
+  Enabled: false
+

--- a/README.md
+++ b/README.md
@@ -120,6 +120,20 @@ if [ -n "$authorized_keys"]; then
 fi
 ```
 
+### SSH Keys
+To use SSH keys insead of passwords to connect to nodes, you'll need to modify your transport_options to look something like:
+
+```ruby
+:transport_options => {
+  :ssh_options => {
+    :auth_methods => ['publickey'],
+    :keys => ['~/.ssh/id_rsa']
+  }
+}
+```
+
+You'll also need to put the corresponding public key(s) into the node's authorized_keys file during the OS setup. See the Custom Attributes section above for one way to do this.
+
 ### Behind a proxy
 Add `:bootstrap_proxy => 'http://proxy.domain.com:8080'` to your convergence_options hash.
 Also, make sure your OS build plans set up the proxy configuration in a post OS install script.

--- a/examples/.chef/knife.rb.example
+++ b/examples/.chef/knife.rb.example
@@ -23,6 +23,7 @@ knife[:icsp_password]      = 'password123'
 knife[:icsp_ignore_ssl]    = true
 
 knife[:node_root_password] = 'password123'
+knife[:node_root_ssh_keys] = ['~/.ssh/id_rsa']
 
 # For self-signed Chef server cert
 verify_api_cert              false

--- a/examples/cookbooks/provisioning_cookbook/recipes/default.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/default.rb
@@ -69,12 +69,12 @@ machine_batch 'oneview-machine-batch' do
         :domainType => 'workgroup',
         :domainName => domain_name,
         :gateway =>  gateway,
+        :mask => mask,
         :dns => dns,
         :connections => {
           #1 => { ... } (Reserved for PXE)
           2 => {
             :ip4Address => options['ip4'],
-            :mask => mask,
             :dhcp => false
           }
         }
@@ -82,7 +82,9 @@ machine_batch 'oneview-machine-batch' do
       :custom_attributes => {},
       :transport_options => {
         :ssh_options => {
-          :password => Chef::Config.knife[:node_root_password]
+          :password => Chef::Config.knife[:node_root_password],
+          :auth_methods => ['password', 'publickey'],
+          :keys => Chef::Config.knife[:node_root_ssh_keys] || []
         }
       },
       :convergence_options => {

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -239,8 +239,8 @@ module OneViewAPI
     power_off(action_handler, machine_spec, chosen_blade['uri'])
     # New-HPOVProfileFromTemplate
     # Create new profile instance from template
-    action_handler.perform_action "Initialize creation of server template for #{machine_spec.name}" do
-      action_handler.report_progress "INFO: Initializing creation of server template for #{machine_spec.name}"
+    action_handler.perform_action "Initialize creation of server profile for #{machine_spec.name}" do
+      action_handler.report_progress "INFO: Initializing creation of server profile for #{machine_spec.name}"
 
       new_template_profile = rest_api(:oneview, :get, "#{template_uri}")
 
@@ -267,7 +267,7 @@ module OneViewAPI
       end
       unless matching_profiles['count'] > 0
         task = rest_api(:oneview, :get, task_uri)
-        fail "Server template coudln't be applied! #{task['taskStatus']}. #{task['taskErrors'].first['message']}"
+        fail "Server profile coudln't be created! #{task['taskStatus']}. #{task['taskErrors'].first['message']}"
       end
     end
     matching_profiles['members'].first
@@ -410,7 +410,7 @@ module OneViewAPI
         fail "Error performing network personalization: #{network_personalization_task['jobResult'].first['jobResultLogDetails']}\n#{network_personalization_task['jobResult'].first['jobResultErrorDetails']}"
       end
     end
-    #   Get all, search for yours.  If not there or if it's in uninitialized state, pull again
+    # Get all, search for yours.  If not there or if it's in uninitialized state, pull again
     my_server_uri = my_server['uri']
     30.times do # Wait for up to 5 min
       my_server = rest_api(:icsp, :get, my_server_uri)

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -267,7 +267,7 @@ module OneViewAPI
       end
       unless matching_profiles['count'] > 0
         task = rest_api(:oneview, :get, task_uri)
-        fail "Server profile coudln't be created! #{task['taskStatus']}. #{task['taskErrors'].first['message']}"
+        fail "Server profile couldn't be created! #{task['taskStatus']}. #{task['taskErrors'].first['message']}"
       end
     end
     matching_profiles['members'].first

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -380,7 +380,7 @@ module OneViewAPI
       if machine_options[:driver_options][:connections]
         machine_options[:driver_options][:connections].each do |id, data|
           c = data
-          c[:macAddress]   = profile['connections'].select {|x| x['id'] == id}.first['mac']
+          c[:macAddress]   = profile['connections'].find {|x| x['id'] == id}['mac']
           c[:mask]       ||= machine_options[:driver_options][:mask]
           c[:dhcp]       ||= machine_options[:driver_options][:dhcp] || false
           c[:gateway]    ||= machine_options[:driver_options][:gateway]

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -91,8 +91,8 @@ module Chef::Provisioning
       bootstrap_ip_address = machine_options[:driver_options][:ip_address]
       username = machine_options[:transport_options][:user] || 'root' rescue 'root'
       default_ssh_options = {
-        # auth_methods: ['publickey'],
-        # keys: ['/home/username/.vagrant.d/insecure_private_key'],
+        # auth_methods: ['password', 'publickey'],
+        # keys: ['~/.ssh/id_rsa'],
         password: Chef::Config.knife[:node_root_password]
       }
       ssh_options = machine_options[:transport_options][:ssh_options] || default_ssh_options rescue default_ssh_options


### PR DESCRIPTION
SSH key support has always been there, but this adds a section to the README telling people how to use keys, and allows people to use them in the examples demo also. Actual driver changes are just gramatical