### PR TITLE
ICsp 7.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,11 @@ machine 'web01' do
           :dhcp => false            # Optional. Overrides dhcp property above
           :gateway => 'xx.xx.xx.1'  # Optional. Overrides gateway property above
           :dns => 'xx.xx.xx.xx'     # Optional. Overrides dns property above
+        },
+        3 => {
+          :dhcp => true             # Optional. Overrides dhcp property above
+          :gateway => :none         # Optional. Overrides gateway property above
+          :dns => :none             # Optional. Overrides dns property above
         }
       },
       :custom_attributes => {
@@ -100,6 +105,8 @@ end
 ```
 
 See https://github.com/chef/chef-provisioning-ssh for more transport_options.
+
+NOTE: Some basic connection settings such as :ip4Address and :dhcp are shown in the example recipe, but you can pass in any interface/nic options that exist in the ICsp api for POST requests to /rest/os-deployment-jobs
 
 ### Custom Attributes
 Insided the custom attributes hash, you can specify any data that you would like to pass into your ICsp build plan scripts or configuration files. For example, to specify a list of trusted public keys to be placed into the node's .ssh/authorized_keys file, add a custom attribute to the machine resource definition:
@@ -139,8 +146,8 @@ Add `:bootstrap_proxy => 'http://proxy.domain.com:8080'` to your convergence_opt
 Also, make sure your OS build plans set up the proxy configuration in a post OS install script.
 
 ### Swtiching to a deadnet after provisioning
-Add `1 => {:net => "Deadnetwork", :deployNet => "PXE Network", :dhcp => true}` to your connections hash per machine. 
-This will flip the first connection of the newly provisioned machine off of your pxe network to your Deadnetwork right after provisioning. Helpful for taking the newly provisioned machine off the PXE network as soon as possible. 
+Add `1 => {:net => "Deadnetwork", :deployNet => "PXE Network", :dhcp => true}` to your connections hash. 
+This will flip the first connection of the newly provisioned machine off of your pxe network to your Deadnetwork right after provisioning. This is helpful for taking the newly provisioned machine off the PXE network as soon as possible. 
 
 # Doing a test run
 This repo contains everything you need to get started, including example recipes and knife configuration files. See the README in the [examples](examples/) directory for how to begin provisioning.

--- a/examples/.chef/knife.rb.example
+++ b/examples/.chef/knife.rb.example
@@ -32,7 +32,7 @@ ssl_verify_mode              :verify_none
 # If you're behind a proxy
 my_proxy = 'http://proxy.domain.com:8080'
 
-# Define your infrastructure here. This info gets populated into the recepe. Leave blank if you want to edit the recipe directly.
+# Define your infrastructure here. This info gets populated into the recipe. Leave blank if you want to edit the recipe directly.
 # Recipe location: chef-provisioning-oneview/examples/cookbooks/provisioning_cookbook/recipes/default.rb
 knife[:example_recipe_options] = {
   'action'      => :converge,  # :stop and :destroy are other options
@@ -47,7 +47,7 @@ knife[:example_recipe_options] = {
       'ip4' => 'xxx.xx.xx.xx'
     },
     'chef-web02' => {
-      'ip4' => 'xxx.xx.xx.xx'
+      'dhcp' => true
     }
   }
 }

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,10 +6,10 @@ This directory contains everything you need to start provisioning with OneView a
  3. Then from this (examples) directory, run: 
 
 ```bash
-$ bundle
+$ chef exec bundle
 $ berks install
 $ berks upload
-$ bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/default.rb
+$ chef exec bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/default.rb
 ```
 
 ## Usage with Chef Zero
@@ -18,10 +18,10 @@ $ bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/default.rb
  2. Then from this (examples) directory, run: 
  
   ```bash
-  $ bundle
+  $ chef exec bundle
   $ berks install
   $ berks upload
-  $ bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/zero.rb
+  $ chef exec bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/zero.rb
   ```
  
  4. If you want to continue and bootstrap the machine, you'll have two options: (1) set up a Chef Server and bootstrap it like normal or (2) copy the cookbooks onto the node and run chef-client in local (zero) mode from there.

--- a/examples/cookbooks/provisioning_cookbook/recipes/default.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/default.rb
@@ -75,7 +75,7 @@ machine_batch 'oneview-machine-batch' do
           #1 => { ... } (Reserved for PXE)
           2 => {
             :ip4Address => options['ip4'],
-            :dhcp => false
+            :dhcp => options['dhcp'] || false
           }
         }
       },

--- a/lib/chef/provisioning/customize_machine.rb
+++ b/lib/chef/provisioning/customize_machine.rb
@@ -25,8 +25,8 @@ module CustomizeMachine
 
     # Get ICSP servers to poll and wait until server PXE complete (to make sure ICSP is available).
     my_server = nil
-    action_handler.perform_action "Wait for #{machine_spec.name} to boot" do
-      action_handler.report_progress "INFO: Waiting for #{machine_spec.name} to PXE boot. This may take a while..."
+    action_handler.perform_action "Wait for #{machine_spec.name} to boot into HP Intelligent Provisioning" do
+      action_handler.report_progress "INFO: Waiting for #{machine_spec.name} to PXE boot into HP Intelligent Provisioning"
       360.times do # Wait for up to 1 hr
         my_server = get_icsp_server_by_sn(profile['serialNumber'])
         break if !my_server.nil?
@@ -36,147 +36,33 @@ module CustomizeMachine
       fail "Timeout waiting for server #{machine_spec.name} to register with ICSP" if my_server.nil?
     end
 
-    # Consume any custom attributes that were specified
-    if machine_options[:driver_options][:custom_attributes]
-      curr_server = rest_api(:icsp, :get, my_server['uri'])
-      machine_options[:driver_options][:custom_attributes].each do |key, val|
-        curr_server['customAttributes'].push({
-          'values' => [{ 'scope' => 'server',  'value' => val.to_s }],
-          'key' => key.to_s
-        })
-      end
-      options = { 'body' => curr_server }
-      rest_api(:icsp, :put, my_server['uri'], options)
-    end
+    icsp_set_custom_attributes(machine_options, my_server)
 
-    # Run OS install on a server
-    unless my_server['opswLifecycle'] == 'MANAGED' # Skip if already in MANAGED state
-      os_build = machine_options[:driver_options][:os_build]
-      action_handler.perform_action "Run: '#{os_build}' OS Build Plan on #{machine_spec.name}" do
-        action_handler.report_progress "INFO: Running: '#{os_build}' OS Build Plan on #{machine_spec.name}"
-        # Get os-deployment-build-plans
-        build_plan_uri = nil
-        os_deployment_build_plans = rest_api(:icsp, :get, '/rest/os-deployment-build-plans')
-        os_deployment_build_plans['members'].each do |bp|
-          if bp['name'] == os_build
-            build_plan_uri = bp['uri']
-            break
-          end
-        end
-        fail "OS build plan #{os_build} not found!" if build_plan_uri.nil?
+    icsp_run_os_install(action_handler, machine_spec, machine_options, my_server, profile)
 
-        # Do the OS deployment
-        options = { 'body' => {
-          'osbpUris' => [build_plan_uri],
-          'serverData' => [{ 'serverUri' => my_server['uri'] }]
-        } }
-        os_deployment_task = rest_api(:icsp, :post, '/rest/os-deployment-jobs/?force=true', options)
-        os_deployment_task_uri = os_deployment_task['uri']
-        fail "Failed to start OS Deployment Job. Details: #{os_deployment_task['details']}" unless os_deployment_task_uri
-        # task = icsp_wait_for(os_deployment_task_uri, 720, sleep_seconds = 10)
-        # fail "Error running OS build plan #{os_build}: #{task['jobResult'].first['jobMessage']}\n#{task['jobResult'].first['jobResultErrorDetails']}" unless task == true
-        720.times do # Wait for up to 2 hr
-          os_deployment_task = rest_api(:icsp, :get, os_deployment_task_uri)
-          break if os_deployment_task['running'] == 'false'
-          print '.'
-          sleep 10
-        end
-        unless os_deployment_task['state'] == 'STATUS_SUCCESS'
-          fail "Error running OS build plan #{os_build}: #{os_deployment_task['jobResult'].first['jobMessage']}\n#{os_deployment_task['jobResult'].first['jobResultErrorDetails']}"
-        end
-      end
-    end
-
-    # Perform network personalization
+    # Customize networking
     if !machine_spec.reference['network_personalitation_finished']
-      action_handler.perform_action "Perform network personalization on #{machine_spec.name}" do
-        action_handler.report_progress "INFO: Performing network personalization on #{machine_spec.name}"
-        nics = []
-        if machine_options[:driver_options][:connections]
-          machine_options[:driver_options][:connections].each do |id, data|
-            c = data
-            next if c[:dhcp] == true
-            begin
-              c[:macAddress]   = profile['connections'].find {|x| x['id'] == id}['mac']
-            rescue NoMethodError
-              ids = []
-              profile['connections'].each {|x| ids.push x['id']}
-              raise "Could not find connection id #{id} for #{profile['name']}. Available connection ids are: #{ids}. Please make sure the connection ids map to those on OneView."
-            end
-            c[:mask]       ||= machine_options[:driver_options][:mask]
-            c[:dhcp]       ||= machine_options[:driver_options][:dhcp] || false
-            c[:gateway]    ||= machine_options[:driver_options][:gateway]
-            c[:dns]        ||= machine_options[:driver_options][:dns]
-            c[:ip4Address] ||= machine_options[:driver_options][:ip_address]
-            nics.push c
-          end
-        end
-        options = { 'body'=> [{
-          'serverUri' => my_server['uri'],
-          'personalityData' => {
-            'hostName'   => machine_options[:driver_options][:host_name],
-            'domainType' => machine_options[:driver_options][:domainType],
-            'domainName' => machine_options[:driver_options][:domainName],
-            'nics'       => nics
-          }
-        }] }
-        network_personalization_task = rest_api(:icsp, :put, '/rest/os-deployment-apxs/personalizeserver', options)
-        fail "Could not perform network personalization task:\n#{network_personalization_task.to_json}" unless network_personalization_task['uri']
-        network_personalization_task_uri = network_personalization_task['uri']
-        60.times do # Wait for up to 10 min
-          network_personalization_task = rest_api(:icsp, :get, network_personalization_task_uri, options)
-          break if network_personalization_task['running'] == 'false'
-          print '.'
-          sleep 10
-        end
-        unless network_personalization_task['state'] == 'STATUS_SUCCESS'
-          fail "Error performing network personalization: #{network_personalization_task['jobResult'].first['jobResultLogDetails']}\n#{network_personalization_task['jobResult'].first['jobResultErrorDetails']}"
-        end
+      icsp_configure_networking(action_handler, machine_spec, machine_options, my_server, profile)
 
-        # Check if task succeeds and ICsp IP config matches machine options
-        requested_ips = []
-        machine_options[:driver_options][:connections].each do |_id, c|
-          requested_ips.push c[:ip4Address] if c[:ip4Address] && c[:dhcp] == false
+      # Switch deploy networks to post-deploy networks if specified
+      if machine_options[:driver_options][:connections]
+        available_networks = rest_api(:oneview, :get, "/rest/server-profiles/available-networks?serverHardwareTypeUri=#{profile['serverHardwareTypeUri']}&enclosureGroupUri=#{profile['enclosureGroupUri']}")
+        machine_options[:driver_options][:connections].each do |id, data|
+          next unless data && data[:net] && data[:deployNet]
+          action_handler.report_progress "INFO: Performing network flipping on #{machine_spec.name}, connection #{id}"
+          deploy_network = available_networks['ethernetNetworks'].find {|n| n['name'] == data[:deployNet] }
+          new_network = available_networks['ethernetNetworks'].find {|n| n['name'] == data[:net] }
+          fail "Failed to perform network flipping on #{machine_spec.name}, connection #{id}. '#{data[:net]}' network not found" if new_network.nil?
+          fail "Failed to perform network flipping on #{machine_spec.name}, connection #{id}. '#{data[:deployNet]}' network not found" if deploy_network.nil?
+          profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
+          profile['connections'].find {|c| c['networkUri'] == deploy_network['uri'] }['networkUri'] = new_network['uri']
+          options = { 'body' => profile }
+          rest_api(:oneview, :put, profile['uri'], options)
         end
-        60.times do
-          my_server_connections = rest_api(:icsp, :get, my_server['uri'])['interfaces']
-          my_server_connections.each { |c| requested_ips.delete c['ipv4Addr'] }
-          break if requested_ips.empty?
-          print '.'
-          sleep 10
-        end
-        fail 'Error setting up ips correctly in ICSP' unless requested_ips.empty?
-
-        # Switch deploy networks to post-deploy networks if specified
-        if machine_options[:driver_options][:connections]
-          available_networks = rest_api(:oneview, :get, "/rest/server-profiles/available-networks?serverHardwareTypeUri=#{profile['serverHardwareTypeUri']}&enclosureGroupUri=#{profile['enclosureGroupUri']}")
-          machine_options[:driver_options][:connections].each do |id, data|
-            next unless data[:net] && data[:deployNet]
-            action_handler.report_progress "INFO: Performing network flipping on #{machine_spec.name}, connection #{id}"
-            deploy_network = available_networks['ethernetNetworks'].find {|n| n['name'] == data[:deployNet] }
-            new_network = available_networks['ethernetNetworks'].find {|n| n['name'] == data[:net] }
-            fail "Failed to perform network flipping on #{machine_spec.name}, connection #{id}. '#{data[:net]}' network not found" if new_network.nil?
-            fail "Failed to perform network flipping on #{machine_spec.name}, connection #{id}. '#{data[:deployNet]}' network not found" if deploy_network.nil?
-            profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
-            profile['connections'].find {|c| c['networkUri'] == deploy_network['uri'] }['networkUri'] = new_network['uri']
-            options = { 'body' => profile }
-            rest_api(:oneview, :put, profile['uri'], options)
-          end
-        end
-        machine_spec.reference['network_personalitation_finished'] = true
       end
+      machine_spec.reference['network_personalitation_finished'] = true
     end
 
-    # Get all, search for yours.  If not there or if it's in uninitialized state, pull again
-    my_server_uri = my_server['uri']
-    30.times do # Wait for up to 5 min
-      my_server = rest_api(:icsp, :get, my_server_uri)
-      break if my_server['opswLifecycle'] == 'MANAGED'
-      print '.'
-      sleep 10
-    end
-
-    fail "Timeout waiting for server #{machine_spec.name} to finish network personalization" if my_server['opswLifecycle'] != 'MANAGED'
-    my_server
+    my_server = rest_api(:icsp, :get, my_server['uri'])
   end
 end

--- a/lib/chef/provisioning/icsp/api_v104.rb
+++ b/lib/chef/provisioning/icsp/api_v104.rb
@@ -1,0 +1,27 @@
+module ICspAPIv104
+  # Parse and clean connection data for api call
+  def icsp_v104_parse_connection(machine_options, c)
+    allowed_keys = %w(macAddress enabled dhcpv4 ipv6autoconfig provisioning dnsServers winsServers dnsSearch staticNetworks vlanid ipv4gateway ipv6gateway)
+    c[:enabled]     ||= true
+    c[:vlanid]      ||= '-1'
+    c[:dhcpv4]      ||= c[:dhcp]
+    c[:ipv4gateway] ||= c[:gateway] || machine_options[:driver_options][:gateway]
+    c[:ipv4gateway]   = nil if c[:ipv4gateway] == :none
+    c[:dnsServers]  ||= c[:dns] || machine_options[:driver_options][:dns] || []
+    c[:dnsServers]    = nil if c[:dnsServers] == :none
+    c[:dnsServers]    = c[:dnsServers].split(',') if c[:dnsServers].class == String
+    c[:staticNetworks] ||= ["#{c[:ip4Address]}/#{c[:mask] || machine_options[:driver_options][:mask] || '24'}"] if c[:ip4Address]
+    c.keep_if {|k, _v| allowed_keys.include? k.to_s }
+  end
+
+  # Parse and clean personality_data data for api call
+  def icsp_v104_build_personality_data(machine_options, nics)
+    allowed_keys = %w(hostname domain workgroup)
+    personality_data = Marshal.load(Marshal.dump(machine_options[:driver_options])) || {}
+    personality_data.keep_if {|k, _v| allowed_keys.include? k.to_s }
+    personality_data['hostname'] ||= machine_options[:driver_options][:host_name]
+    personality_data['domain']   ||= machine_options[:driver_options][:domainName]
+    personality_data['interfaces'] = nics
+    personality_data
+  end
+end

--- a/lib/chef/provisioning/icsp/icsp_api.rb
+++ b/lib/chef/provisioning/icsp/icsp_api.rb
@@ -1,5 +1,9 @@
+Dir[File.dirname(__FILE__) + '/**/*.rb'].each {|file| require file } # Include all helper files in this directory & subdirectories
+
 module ICspAPI
   private
+
+  include ICspAPIv104
 
   def get_icsp_api_version
     begin
@@ -63,7 +67,7 @@ module ICspAPI
         when 'error', 'killed', 'terminated'
           return task
         end
-      elsif task['running'] == 'false'
+      elsif task['running'] == 'false' && task['jobResult']
         if task['state'] == 'STATUS_SUCCESS'
           return true
         else
@@ -76,13 +80,147 @@ module ICspAPI
     false
   end
 
+  # Consume and set any custom attributes that were specified
+  def icsp_set_custom_attributes(machine_options, my_server)
+    if machine_options[:driver_options][:custom_attributes]
+      curr_server = rest_api(:icsp, :get, my_server['uri'])
+      machine_options[:driver_options][:custom_attributes].each do |key, val|
+        curr_server['customAttributes'].push({
+          'values' => [{ 'scope' => 'server',  'value' => val.to_s }],
+          'key' => key.to_s
+        })
+      end
+      options = { 'body' => curr_server }
+      rest_api(:icsp, :put, my_server['uri'], options)
+    end
+  end
+
+  def icsp_run_os_install(action_handler, machine_spec, machine_options, my_server, profile)
+    return if my_server['state'] == 'OK' # Skip if the OS has already been deployed
+
+    # Wait for my_server['state'] to be in MAINTENANCE mode
+    if my_server['state'] != 'MAINTENANCE'
+      action_handler.perform_action "Wait for #{machine_spec.name} to go into maintenance mode" do
+        action_handler.report_progress "INFO: Waiting for #{machine_spec.name} to go into maintenance mode"
+        120.times do # Wait for up to 20 min
+          my_server = get_icsp_server_by_sn(profile['serialNumber'])
+          break if my_server['state'] != 'MAINTENANCE'
+          print '.'
+          sleep 10
+        end
+        fail "Timed out waiting for #{machine_spec.name} to go into maintenance mode. State: #{my_server['state']}" unless my_server['state'] == 'MAINTENANCE'
+      end
+    end
+
+    # Get the specified OS Build Plan(s)
+    os_builds = machine_options[:driver_options][:os_build]
+    os_builds = [os_builds] if os_builds.class == String
+    build_plan_uris = []
+    action_handler.perform_action "Get OS Build Plan(s) info for #{machine_spec.name}" do
+      action_handler.report_progress "INFO: Getting OS Build Plan(s) for #{machine_spec.name}"
+      os_deployment_build_plans = rest_api(:icsp, :get, '/rest/os-deployment-build-plans')
+      os_builds.each do |os_build|
+        build_plan_uri = os_deployment_build_plans['members'].find {|bp| bp['name'] == os_build}['uri'] rescue nil
+        fail "OS build plan #{os_build} not found!" if build_plan_uri.nil?
+        build_plan_uris.push build_plan_uri
+      end
+    end
+
+    # Build options for the OS deployment
+    options = {}
+    options['X-API-Version'] = 104 if @current_icsp_api_version.between?(104, 108)
+    options['body'] = {
+      'osbpUris' => build_plan_uris,
+      'serverData' => [{
+        'serverUri' => my_server['uri']
+      }]
+    }
+
+    # Do the OS deployment
+    action_handler.perform_action "Run: #{os_builds} OS Build Plan(s) on #{machine_spec.name}" do
+      action_handler.report_progress "INFO: Running: #{os_builds} OS Build Plan(s) on #{machine_spec.name}"
+      task = rest_api(:icsp, :post, '/rest/os-deployment-jobs/?force=true', options)
+      task_uri = task['uri']
+      fail "Failed to start OS Deployment Job. Details: #{task['details']}" unless task_uri
+      task = icsp_wait_for(task_uri, 720)
+      fail "Error running OS build plan(s) #{os_builds}: #{task['jobResult'].first['jobMessage']}\n#{task['jobResult'].first['jobResultErrorDetails']}" unless task == true
+    end
+  end
+
+  def icsp_configure_networking(action_handler, machine_spec, machine_options, my_server, profile)
+    action_handler.perform_action "Configure networking on #{machine_spec.name}" do
+      action_handler.report_progress "INFO: Configuring networking on #{machine_spec.name}"
+      personality_data = icsp_build_personality_data(machine_options, profile)
+      options = {}
+      options['X-API-Version'] = 104 if @current_icsp_api_version.between?(104, 108)
+      options['body'] = {
+        'serverData' => [{
+          'serverUri' => my_server['uri'],
+          'personalityData' => personality_data
+        }]
+      }
+      task = rest_api(:icsp, :post, '/rest/os-deployment-jobs/?force=true', options)
+      task_uri = task['uri']
+      fail "Failed to start network personalization job. Details: #{task['details']}" unless task_uri
+      task = icsp_wait_for(task_uri, 60) # Wait for up to 10 min
+      fail "Error running network personalization job: #{task['jobResult'].first['jobMessage']}\n#{task['jobResult'].first['jobResultErrorDetails']}" unless task == true
+    end
+
+    # Check if ICsp IP config matches machine options
+    requested_ips = []
+    machine_options[:driver_options][:connections].each do |_id, c|
+      requested_ips.push c[:ip4Address] if c[:ip4Address] && c[:dhcp] == false
+    end
+    my_server_connections = rest_api(:icsp, :get, my_server['uri'])['interfaces']
+    my_server_connections.each { |c| requested_ips.delete c['ipv4Addr'] }
+    puts "\nWARN: The following IPs might not have gotten configured correctly on ICsp: #{requested_ips}" unless requested_ips.empty?
+  end
+
+  # Build options for the network configuration
+  def icsp_build_personality_data(machine_options, profile)
+    nics = []
+    if machine_options[:driver_options][:connections]
+      machine_options[:driver_options][:connections].each do |id, data|
+        c = Marshal.load(Marshal.dump(data))
+        next unless c[:dhcp] || c[:dhcpv4] || c[:ip4Address] || c[:ipv6autoconfig] || c[:staticNetworks] # Invalid network or only switch networks specified
+        begin
+          c[:macAddress] = profile['connections'].find {|x| x['id'] == id}['mac']
+        rescue NoMethodError
+          ids = []
+          profile['connections'].each {|x| ids.push x['id']}
+          raise "Could not find connection id #{id} for #{profile['name']}. Available connection ids are: #{ids}. Please make sure the connection ids map to those on OneView."
+        end
+        if @current_icsp_api_version.between?(104, 108)
+          icsp_v104_parse_connection(machine_options, c)
+        else
+          c[:mask]    ||= machine_options[:driver_options][:mask]
+          c[:dhcp]    ||= false
+          c[:gateway] ||= machine_options[:driver_options][:gateway]
+          c[:dns]     ||= machine_options[:driver_options][:dns]
+        end
+        nics.push c
+      end
+    end
+
+    if @current_icsp_api_version.between?(104, 108)
+      personality_data = icsp_v104_build_personality_data(machine_options, nics)
+    else
+      personality_data = {
+        'hostName' => machine_options[:driver_options][:host_name],
+        'domainType' => machine_options[:driver_options][:domainType],
+        'domainName' => machine_options[:driver_options][:domainName],
+        'nics' => nics
+      }
+    end
+    personality_data
+  end
+
   def destroy_icsp_server(action_handler, machine_spec)
     my_server = get_icsp_server_by_sn(machine_spec.reference['serial_number'])
     return false if my_server.nil? || my_server['uri'].nil?
 
     action_handler.perform_action "Delete server #{machine_spec.name} from ICSP" do
       task = rest_api(:icsp, :delete, my_server['uri']) # TODO: This returns nil instead of task info
-
       if task['uri']
         task_uri = task['uri']
         90.times do # Wait for up to 15 minutes

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -1,5 +1,4 @@
-require_relative 'v1.2/api'
-require_relative 'v2.0/api'
+Dir[File.dirname(__FILE__) + '/**/*.rb'].each {|file| require file } # Include all helper files in this directory & subdirectories
 
 module OneViewAPI
   private


### PR DESCRIPTION
This...
- Adds support for ICsp 7.4.1 and 7.5.
- Splits up the customize_machine method into more modular, manageable methods.
- Fixes issue with ICsp wait_for method where delayed jobs would return as failed before they even started.