### PR TITLE
DHCP support & Version bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Currently supports:
   ```
 
 - Your OneView, Insight Controll Server Provisioning(ICSP), and Chef server must be trusted by your certificate stores. See [examples/ssl_issues.md](examples/ssl_issues.md) for more info on how to do this.
-- Your OneView and ICSP servers must be set up beforehand. Unfortunately, this driver doesn't do that for you too. See the wiki pages [OneView Configuration](https://github.com/HewlettPackard/chef-provisioning-oneview/wiki/OneView-Configuration) and [ICsp Configuration](https://github.com/HewlettPackard/chef-provisioning-oneview/wiki/ICsp-Configuration) for details about how to set them up.
+- Your OneView and ICSP servers must be set up beforehand. Unfortunately, this driver doesn't do that for you too.
 
 # Usage
 
@@ -67,7 +67,7 @@ machine 'web01' do
       :server_template => 'Web Server Template',
       :os_build => 'CHEF-RHEL-6.5-x64',
       :host_name => 'chef-web01',
-      :ip_address => 'xx.xx.xx.xx', # For bootstrapping only.
+      :ip_address => 'xx.xx.xx.xx', # For bootstrapping. Deprecated in favor of { bootstrap: true } in connection; see below
       
       :domainType => 'workgroup',
       :domainName => 'sub.domain.com',
@@ -83,6 +83,7 @@ machine 'web01' do
           :dhcp => false            # Optional. Overrides dhcp property above
           :gateway => 'xx.xx.xx.1'  # Optional. Overrides gateway property above
           :dns => 'xx.xx.xx.xx'     # Optional. Overrides dns property above
+          :bootstrap => true        # Set this on 1 connection only. Tells Chef which connection to use to bootstrap.
         },
         3 => {
           :dhcp => true             # Optional. Overrides dhcp property above

--- a/examples/cookbooks/my_apache_server/recipes/default.rb
+++ b/examples/cookbooks/my_apache_server/recipes/default.rb
@@ -35,6 +35,7 @@ remote_directory document_root do
   files_mode '0755'
   source 'oneview'
   notifies :restart, 'service[httpd]', :delayed
+  sensitive true
 end
 
 service 'httpd' do

--- a/examples/cookbooks/provisioning_cookbook/recipes/default.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/default.rb
@@ -64,7 +64,7 @@ machine_batch 'oneview-machine-batch' do
         :server_template => my_template,
         :os_build => os_build,
         :host_name => m_name,
-        :ip_address => options['ip4'], # For bootstrapping only.
+        # :ip_address => options['ip4'], # For bootstrapping. Deprecated in favor of { bootstrap: true } in connection
 
         :domainType => 'workgroup',
         :domainName => domain_name,
@@ -72,10 +72,11 @@ machine_batch 'oneview-machine-batch' do
         :mask => mask,
         :dns => dns,
         :connections => {
-          #1 => { ... } (Reserved for PXE)
+          # 1 => { dhcp: true }, # (Reserved for PXE)
           2 => {
             :ip4Address => options['ip4'],
-            :dhcp => options['dhcp'] || false
+            :dhcp => options['dhcp'] || false,
+            :bootstrap => true
           }
         }
       },

--- a/lib/chef/provisioning/icsp/icsp_api.rb
+++ b/lib/chef/provisioning/icsp/icsp_api.rb
@@ -177,6 +177,7 @@ module ICspAPI
       machine_options[:driver_options][:connections].each do |_id, c|
         requested_ips.push c[:ip4Address] if c[:ip4Address] && c[:dhcp] == false
       end
+      my_server_connections = []
       10.times do
         my_server_connections = rest_api(:icsp, :get, my_server['uri'])['interfaces']
         my_server_connections.each { |c| requested_ips.delete c['ipv4Addr'] }
@@ -185,6 +186,13 @@ module ICspAPI
         sleep 10
       end
       puts "\nWARN: The following IPs are not visible on ICsp, so they may not have gotten configured correctly: #{requested_ips}" unless requested_ips.empty?
+
+      # Set interface data as normal node attributes
+      my_server_connections.each do |c|
+        c['oneViewId'] = profile['connections'].find {|x| x['mac'] == c['macAddr']}['id'] rescue nil
+      end
+      machine_spec.data['normal']['icsp'] ||= {}
+      machine_spec.data['normal']['icsp']['interfaces'] = my_server_connections
     end
   end
 

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -103,12 +103,12 @@ module Chef::Provisioning
     def machine_for(machine_spec, machine_options)
       bootstrap_ip_address = machine_options[:driver_options][:ip_address]
       unless bootstrap_ip_address
-        profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
-        my_server = get_icsp_server_by_sn(machine_spec.reference['serial_number'])
         id, connection = machine_options[:driver_options][:connections].find { |_id, c| c[:bootstrap] == true }
         fail 'Must specify a connection to use to bootstrap!' unless id && connection
         bootstrap_ip_address = connection[:ip4Address] # For static IPs
         unless bootstrap_ip_address # Look for dhcp address given to this connection
+          profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
+          my_server = get_icsp_server_by_sn(machine_spec.reference['serial_number'])
           mac = profile['connections'].find {|x| x['id'] == id}['mac']
           interface = my_server['interfaces'].find { |i| i['macAddr'] == mac }
           bootstrap_ip_address = interface['ipv4Addr'] || interface['ipv6Addr']

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -68,6 +68,9 @@ module Chef::Provisioning
         if get_oneview_profile_by_sn(machine_spec.reference['serial_number']).nil? # It doesn't really exist
           action_handler.report_progress "Machine #{host_name} does not really exist.  Recreating ..."
           machine_spec.reference = nil
+        else # Update reference data
+          machine_spec.reference['driver_url'] = driver_url
+          machine_spec.reference['driver_version'] = ONEVIEW_DRIVER_VERSION
         end
       end
       if !machine_spec.reference
@@ -99,6 +102,20 @@ module Chef::Provisioning
 
     def machine_for(machine_spec, machine_options)
       bootstrap_ip_address = machine_options[:driver_options][:ip_address]
+      unless bootstrap_ip_address
+        profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
+        my_server = get_icsp_server_by_sn(machine_spec.reference['serial_number'])
+        id, connection = machine_options[:driver_options][:connections].find { |_id, c| c[:bootstrap] == true }
+        fail 'Must specify a connection to use to bootstrap!' unless id && connection
+        bootstrap_ip_address = connection[:ip4Address] # For static IPs
+        unless bootstrap_ip_address # Look for dhcp address given to this connection
+          mac = profile['connections'].find {|x| x['id'] == id}['mac']
+          interface = my_server['interfaces'].find { |i| i['macAddr'] == mac }
+          bootstrap_ip_address = interface['ipv4Addr'] || interface['ipv6Addr']
+        end
+        bootstrap_ip_address ||= my_server['hostName'] # Fall back on hostName
+      end
+      fail 'Server IP address not specified and could not be retrieved!' unless bootstrap_ip_address
       username = machine_options[:transport_options][:user] || 'root' rescue 'root'
       default_ssh_options = {
         # auth_methods: ['password', 'publickey'],

--- a/lib/chef/provisioning/version.rb
+++ b/lib/chef/provisioning/version.rb
@@ -1,5 +1,5 @@
 class Chef
   module Provisioning
-    ONEVIEW_DRIVER_VERSION = '1.0.1'
+    ONEVIEW_DRIVER_VERSION = '1.1.0'
   end
 end


### PR DESCRIPTION
This PR adds full DHCP support so you can bootstrap a machine from a network that gets it's IP from dhcp.  It also stores the ICSP interface data in the machines' node attributes (`node['icsp']['interfaces']`) and bumps up a minor version.