### PR TITLE
add skip_configure_networking option

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ machine 'web01' do
           :dns => :none             # Optional. Overrides dns property above
         }
       },
+      :skip_network_configuration => false, # Default. Set to true for EXSi hosts, etc.
       :custom_attributes => {
         :chefCert => 'ssh-rsa AA...' # Optional
       }

--- a/lib/chef/provisioning/icsp/icsp_api.rb
+++ b/lib/chef/provisioning/icsp/icsp_api.rb
@@ -34,11 +34,11 @@ module ICspAPI
     fail("\nERROR! Couldn't log into OneView server at #{@oneview_base_url}. Response:\n#{response}")
   end
 
-  def get_icsp_server_by_sn(serialNumber)
-    fail 'Must specify a serialNumber!' if serialNumber.nil? || serialNumber.empty?
+  def get_icsp_server_by_sn(serial_number)
+    fail 'Must specify a serialNumber!' if serial_number.nil? || serial_number.empty?
     search_result = rest_api(:icsp, :get,
-      "/rest/index/resources?category=osdserver&query='osdServerSerialNumber:\"#{serialNumber}\"'")['members'] rescue nil
-    if search_result && search_result.size == 1 && search_result.first['attributes']['osdServerSerialNumber'] == serialNumber
+      "/rest/index/resources?category=osdserver&query='osdServerSerialNumber:\"#{serial_number}\"'")['members'] rescue nil
+    if search_result && search_result.size == 1 && search_result.first['attributes']['osdServerSerialNumber'] == serial_number
       my_server_uri = search_result.first['uri']
       my_server = rest_api(:icsp, :get, my_server_uri)
     end
@@ -47,7 +47,7 @@ module ICspAPI
       # Pick the relevant os deployment server from icsp
       my_server = nil
       os_deployment_servers['members'].each do |server|
-        if server['serialNumber'] == serialNumber
+        if server['serialNumber'] == serial_number
           my_server = server
           break
         end
@@ -154,6 +154,7 @@ module ICspAPI
   end
 
   def icsp_configure_networking(action_handler, machine_spec, machine_options, my_server, profile)
+    return if machine_options[:driver_options][:skip_network_configuration] == true
     action_handler.perform_action "Configure networking on #{machine_spec.name}" do
       action_handler.report_progress "INFO: Configuring networking on #{machine_spec.name}"
       personality_data = icsp_build_personality_data(machine_options, profile)

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -36,10 +36,10 @@ module OneViewAPI
     fail("\nERROR! Couldn't log into OneView server at #{@oneview_base_url}. Response:\n#{response}")
   end
 
-  def get_oneview_profile_by_sn(serialNumber)
-    fail 'Must specify a serialNumber!' if serialNumber.nil? || serialNumber.empty?
-    matching_profiles = rest_api(:oneview, :get, "/rest/server-profiles?filter=serialNumber matches '#{serialNumber}'&sort=name:asc")
-    fail "Failed to get oneview profile by serialNumber: #{serialNumber}. Response: #{matching_profiles}" unless matching_profiles['count']
+  def get_oneview_profile_by_sn(serial_number)
+    fail 'Must specify a serialNumber!' if serial_number.nil? || serial_number.empty?
+    matching_profiles = rest_api(:oneview, :get, "/rest/server-profiles?filter=serialNumber matches '#{serial_number}'&sort=name:asc")
+    fail "Failed to get oneview profile by serialNumber: #{serial_number}. Response: #{matching_profiles}" unless matching_profiles['count']
     return matching_profiles['members'].first if matching_profiles['count'] > 0
     nil
   end

--- a/lib/chef/provisioning/version.rb
+++ b/lib/chef/provisioning/version.rb
@@ -1,5 +1,5 @@
 class Chef
   module Provisioning
-    ONEVIEW_DRIVER_VERSION = '1.1.0'
+    ONEVIEW_DRIVER_VERSION = '1.1.1'
   end
 end


### PR DESCRIPTION
Fixes Issue #32 
This adds an option to skip the icsp_configure_networking task by specifying a driver option (`:skip_network_configuration`). This is useful for EXSi hosts, etc which will cause the icsp_configure_networking task to fail.

It also makes rubocop happy for some methods that don't use snake_case variable names