### PR TITLE
install_gems example recipe & doc updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # chef-provisioning-oneview
-Chef Provisioning driver for HP OneView
+Chef Provisioning driver for HPE OneView
 
 
 [![Build Status](https://travis-ci.org/HewlettPackard/chef-provisioning-oneview.svg?branch=master)](https://travis-ci.org/HewlettPackard/chef-provisioning-oneview)
@@ -14,17 +14,16 @@ Currently supports:
 
 # Installation
 
-- Install Ruby and the `ruby-devel` or `ruby-dev` package for your system.
-  
-- Require the gem in your Gemfile: `gem 'chef-provisioning-oneview'`
-  
-  Then run `$ bundle install`
-- Or run the command:
-  
+- This program is meant to run inside the chef-client, so to install it, add the following to a Chef recipe and run it:
   ```ruby
-  $ gem install chef-provisioning-oneview
+  chef_gem 'chef-provisioning-oneview'
   ```
-
+  
+- To install it on your system Ruby for development purposes:
+  - Install Ruby and the `ruby-devel` or `ruby-dev` package for your system.
+    
+  - Option 1: Require the gem in your Gemfile: `gem 'chef-provisioning-oneview'`, then run `$ bundle install`
+  - Option 2: Run the command: `$ gem install chef-provisioning-oneview`
 
 
 # Prerequisites

--- a/README.md
+++ b/README.md
@@ -171,6 +171,10 @@ Add `:team => 'TeamName'` into a connection in your connections hash. Make sure 
 This repo contains everything you need to get started, including example recipes and knife configuration files. See the README in the [examples](examples/) directory for how to begin provisioning.
 
 
+# Troubleshooting
+See the [Trouleshooting wiki page](https://github.com/HewlettPackard/chef-provisioning-oneview/wiki/Troubleshooting)
+
+
 # Contributing
 You know the drill. Fork it, branch it, change it, commit it, pull-request it. We're passionate about improving this driver, and glad to accept help to make it better.
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -39,3 +39,5 @@ This directory contains everything you need to start provisioning with OneView a
 ## Troubleshooting
 
 - One of the most common problems people run into is ssl certificate verification issues with private Chef servers. See [ssl_issues.md](ssl_issues.md) to fix these errors.
+
+- Also see the [Trouleshooting wiki page](https://github.com/HewlettPackard/chef-provisioning-oneview/wiki/Troubleshooting)

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,27 +1,37 @@
 This directory contains everything you need to start provisioning with OneView and Chef.
 
 ## Usage with a Chef Server
- 1. Create `.chef/<CLIENT_NAME>.pem` and `.chef/oneview-validator.pem` files, and populate them with your client and validator keys for your Chef server org.
- 2. Create `.chef/knife.rb` using the `.chef/knife.rb.example` file as a template. Fill it with the correct info for your Chef server. It also contains a data hash for provisioning the oneview machines. You can either fill the data out here, or edit the recipe at `cookbooks/provisioning_cookbook/recipes/default.rb` directly.
- 3. Then from this (examples) directory, run: 
-
-```bash
-$ chef exec bundle
-$ berks install
-$ berks upload
-$ chef exec bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/default.rb
-```
-
-## Usage with Chef Zero
-**NOTE:** This provisioner will provision the node, install the OS, and configure networking, but it **won't** be able to bootstrap the node and apply a runlist. You'll have to bootstrap it as a seperate step. This is because zero will pass a chef_server_url parameter of "chefzero://localhost:8889" to the node at bootstrap time, which the node won't be able to resolve to your machine.
- 1. Create `.chef/knife.rb` using the `.chef/knife.rb.example` file as a template. Fill it with the correct info for your OneView and ICSP instances. You don't have to worry about the Chef Server info or the client or validator keys.  This file also contains a data hash for provisioning the oneview machines. You can either fill the data out here, or edit the recipe at `cookbooks/provisioning_cookbook/recipes/zero.rb` directly.
- 2. Then from this (examples) directory, run: 
+ **Requirements:** ChefDK installed on your workstation.
  
+ 1. Create `.chef/<CLIENT_NAME>.pem` and `.chef/oneview-validator.pem` files, and populate them with your client and validator keys for your Chef server org.
+ 2. Create `.chef/knife.rb` using the `.chef/knife.rb.example` file as a template. Fill it with the correct info for your Chef server. It also contains a data hash for provisioning the oneview machines. You can either fill the data out here, or advanced users may edit the recipe at `cookbooks/provisioning_cookbook/recipes/default.rb` directly.
+ 3. Then from this (examples) directory, run: 
+  
   ```bash
-  $ chef exec bundle
+  # Upload the cookbooks to your Chef server using berkshelf:
   $ berks install
   $ berks upload
-  $ bundle exec chef-client -z cookbooks/provisioning_cookbook/recipes/zero.rb
+  
+  # Install chef-provisioning-oneview as a Chef gem:
+  $ chef-client -z -o provisioning_cookbook::install_gems
+  
+  # Run the provisioning cookbook:
+  $ chef-client -z -o provisioning_cookbook
+  ```
+
+## Usage with Chef Zero
+**Requirements:** chef-client or ChefDK installed on your workstation.
+
+**NOTE:** This provisioner will provision the node, install the OS, and configure networking, but it **won't** be able to bootstrap the node and apply a runlist. You'll have to bootstrap it as a seperate step. This is because zero will pass a chef_server_url parameter of "chefzero://localhost:8889" to the node at bootstrap time, which the node won't be able to resolve to your machine.
+ 1. Create `.chef/knife.rb` using the `.chef/knife.rb.example` file as a template. Fill it with the correct info for your OneView and ICSP instances. You don't have to worry about the Chef Server info or the client or validator keys.  This file also contains a data hash for provisioning the oneview machines. You can either fill the data out here, or advanced users may edit the recipe at `cookbooks/provisioning_cookbook/recipes/zero.rb` directly.
+ 2. Then from this (examples) directory, run: 
+  
+  ```bash
+  # Install chef-provisioning-oneview as a Chef gem:
+  $ chef-client -z -o provisioning_cookbook::install_gems
+  
+  # Run the provisioning cookbook:
+  $ chef-client -z -o provisioning_cookbook::zero
   ```
  
  4. If you want to continue and bootstrap the machine, you'll have two options: (1) set up a Chef Server and bootstrap it like normal or (2) copy the cookbooks onto the node and run chef-client in local (zero) mode from there.

--- a/examples/cookbooks/provisioning_cookbook/.kitchen.yml
+++ b/examples/cookbooks/provisioning_cookbook/.kitchen.yml
@@ -3,11 +3,11 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
 
 platforms:
-  - name: ubuntu-12.04
-  - name: centos-6.4
+  - name: ubuntu-14.04
+  - name: centos-6.7
 
 suites:
   - name: default

--- a/examples/cookbooks/provisioning_cookbook/Gemfile
+++ b/examples/cookbooks/provisioning_cookbook/Gemfile
@@ -1,8 +1,8 @@
 source 'https://rubygems.org'
 
 gem 'berkshelf'
-gem "test-kitchen"
-gem "kitchen-vagrant"
+gem 'test-kitchen'
+gem 'kitchen-vagrant'
 gem 'chefspec'
 gem 'foodcritic'
-gem "chef-provisioning-oneview"
+gem 'chef-provisioning-oneview'

--- a/examples/cookbooks/provisioning_cookbook/LICENSE
+++ b/examples/cookbooks/provisioning_cookbook/LICENSE
@@ -1,3 +1,3 @@
-Copyright (C) 2015 HP
+Copyright (C) Hewlett Packard Enterprise
 
 All rights reserved - Do Not Redistribute

--- a/examples/cookbooks/provisioning_cookbook/metadata.rb
+++ b/examples/cookbooks/provisioning_cookbook/metadata.rb
@@ -1,6 +1,6 @@
 name             'provisioning_cookbook'
 maintainer       'Jared Smartt'
-maintainer_email 'jared.smartt@hp.com'
+maintainer_email 'jared.smartt@hpe.com'
 license          'All rights reserved'
 description      'Uses chef-provisioning-oneview'
 long_description 'Uses chef-provisioning-oneview'

--- a/examples/cookbooks/provisioning_cookbook/recipes/default.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/default.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: provisioning_cookbook
 # Recipe:: default
 #
-# Copyright (C) 2015 HP
+# Copyright (C) Hewlett Packard Enterprise
 #
 # All rights reserved - Do Not Redistribute
 #

--- a/examples/cookbooks/provisioning_cookbook/recipes/install_gems.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/install_gems.rb
@@ -1,0 +1,10 @@
+#
+# Cookbook Name:: provisioning_cookbook
+# Recipe:: default
+#
+# Copyright (C) Hewlett Packard Enterprise
+#
+# All rights reserved - Do Not Redistribute
+#
+
+chef_gem 'chef-provisioning-oneview'

--- a/examples/cookbooks/provisioning_cookbook/recipes/zero.rb
+++ b/examples/cookbooks/provisioning_cookbook/recipes/zero.rb
@@ -2,7 +2,7 @@
 # Cookbook Name:: provisioning_cookbook
 # Recipe:: default
 #
-# Copyright (C) 2015 HP
+# Copyright (C) Hewlett Packard Enterprise
 #
 # All rights reserved - Do Not Redistribute
 #


### PR DESCRIPTION
This updates the documentation in a few places, mainly how to install it, and how the commands for the examples.

Previous instructions showed how to use with system ruby installation, but we should really be using this with the ruby included with Chef.