### PR TITLE
Moved this from :master to :ForkBranch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# FORK from original release for testing of new features to be added into Master
+
+ICSP is no longer required, so skip it from your knife.rb config if you want to use the DCS
+To use specific blades, in your recipe use a line like e.g. `:server_location => 'Encl1, bay 16',`
+
+
 # chef-provisioning-oneview
 Chef Provisioning driver for HPE OneView
 

--- a/lib/chef/provisioning/create_machine.rb
+++ b/lib/chef/provisioning/create_machine.rb
@@ -17,8 +17,14 @@ module CreateMachine
     # Search for OneView Template by name
     template = get_oneview_template(machine_options[:driver_options][:server_template])
 
-    # Get first availabe (and compatible) HP OV server blade
-    chosen_blade = available_hardware_for_template(template)
+    # Get first availabe (and compatible) HP OV server blade or if a 
+    # Server location has been specified, use that blade
+    if machine_options[:driver_options][:server_location].nil?
+       chosen_blade = available_hardware_for_template(template)
+    else
+       puts 'Specific Blade'
+       chosen_blade = hardware_for_template_with_location(template, machine_options[:driver_options][:server_location])
+    end
 
     power_off(action_handler, machine_spec, chosen_blade['uri'])
 

--- a/lib/chef/provisioning/create_machine.rb
+++ b/lib/chef/provisioning/create_machine.rb
@@ -17,13 +17,13 @@ module CreateMachine
     # Search for OneView Template by name
     template = get_oneview_template(machine_options[:driver_options][:server_template])
 
-    # Get first availabe (and compatible) HP OV server blade or if a 
+    # Get first availabe (and compatible) HP OV server blade or if a
     # Server location has been specified, use that blade
     if machine_options[:driver_options][:server_location].nil?
-       chosen_blade = available_hardware_for_template(template)
+      chosen_blade = available_hardware_for_template(template)
     else
-       Chef::Log.warn "Specific hardware is being allocated"
-       chosen_blade = hardware_for_template_with_location(template, machine_options[:driver_options][:server_location])
+      Chef::Log.warn 'Specific hardware is being allocated'
+      chosen_blade = hardware_for_template_with_location(template, machine_options[:driver_options][:server_location])
     end
 
     power_off(action_handler, machine_spec, chosen_blade['uri'])

--- a/lib/chef/provisioning/create_machine.rb
+++ b/lib/chef/provisioning/create_machine.rb
@@ -22,7 +22,7 @@ module CreateMachine
     if machine_options[:driver_options][:server_location].nil?
        chosen_blade = available_hardware_for_template(template)
     else
-       puts 'Specific Blade'
+       Chef::Log.warn "Specific hardware is being allocated"
        chosen_blade = hardware_for_template_with_location(template, machine_options[:driver_options][:server_location])
     end
 

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -100,6 +100,23 @@ module OneViewAPI
     false
   end
 
+  def wait_for_profile(action_handler, machine_spec,machine_options,  profile)
+    unless profile['state'] == 'Normal'
+      action_handler.perform_action "Wait for #{machine_spec.name} server to start and profile to be applied" do
+        action_handler.report_progress "INFO: Waiting for #{machine_spec.name} server to start and profile to be applied"
+        task = oneview_wait_for(profile['taskUri'], 360) # Wait up to 60 min for profile to be created
+        raise 'Timed out waiting for server to start and profile to be applied' if task == false
+        unless task == true
+          server_template = machine_options[:driver_options][:server_template]
+          raise "Error creating server profile from template #{server_template}: #{task['taskErrors'].first['message']}"
+        end
+      end
+      profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number']) # Refresh profile
+      raise "Server profile state '#{profile['state']}' not 'Normal'" unless profile['state'] == 'Normal'
+    end
+  end
+
+
   def power_on(action_handler, machine_spec, hardware_uri = nil)
     set_power_state(action_handler, machine_spec, 'on', hardware_uri)
   end

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -83,6 +83,23 @@ module OneViewAPI
     raise 'No more blades are available for provisioning!' # Every bay is full and no more machines can be allocated
   end
 
+    def hardware_for_template_with_location(template, location)
+    server_hardware_type_uri = template['serverHardwareTypeUri']
+    enclosure_group_uri      = template['enclosureGroupUri']
+    raise 'Template must specify a valid hardware type uri!' if server_hardware_type_uri.nil? || server_hardware_type_uri.empty?
+    raise 'Template must specify a valid hardware type uri!' if enclosure_group_uri.nil? || enclosure_group_uri.empty?
+    raise 'Location can not be determined' if location.nil? || location.empty?
+    params = "sort=name:asc&filter=serverHardwareTypeUri='#{server_hardware_type_uri}'&filter=serverGroupUri='#{enclosure_group_uri}'"
+    blades = rest_api(:oneview, :get, "/rest/server-hardware?#{params}")
+    raise 'Error! No available blades that are compatible with the server template!' unless blades['count'] > 0
+    blades['members'].each do |member|
+      return member if member['state'] == 'NoProfileApplied' && member['name'] == location
+    end
+    raise 'No more blades are available for provisioning!' # Every bay is full and no more machines can be allocated
+  end
+
+  
+
   def oneview_wait_for(task_uri, wait_iterations = 60, sleep_seconds = 10) # Default time is 10 min
     raise 'Must specify a task_uri!' if task_uri.nil? || task_uri.empty?
     wait_iterations.times do

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -98,8 +98,6 @@ module OneViewAPI
     raise 'No more blades are available for provisioning!' # Every bay is full and no more machines can be allocated
   end
 
-  
-
   def oneview_wait_for(task_uri, wait_iterations = 60, sleep_seconds = 10) # Default time is 10 min
     raise 'Must specify a task_uri!' if task_uri.nil? || task_uri.empty?
     wait_iterations.times do
@@ -117,7 +115,7 @@ module OneViewAPI
     false
   end
 
-  def wait_for_profile(action_handler, machine_spec,machine_options,  profile)
+  def wait_for_profile(action_handler, machine_spec, machine_options,  profile)
     unless profile['state'] == 'Normal'
       action_handler.perform_action "Wait for #{machine_spec.name} server to start and profile to be applied" do
         action_handler.report_progress "INFO: Waiting for #{machine_spec.name} server to start and profile to be applied"

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -115,6 +115,7 @@ module OneViewAPI
       end
     end
     false
+    puts ''
   end
 
   def wait_for_profile(action_handler, machine_spec,machine_options,  profile)
@@ -131,6 +132,7 @@ module OneViewAPI
       profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number']) # Refresh profile
       raise "Server profile state '#{profile['state']}' not 'Normal'" unless profile['state'] == 'Normal'
     end
+    puts ''
   end
 
 
@@ -172,6 +174,7 @@ module OneViewAPI
         raise "Powering #{state} machine #{machine_spec.name} failed!" unless task['taskState'].casecmp('completed') == 0
       end
     end
+    puts ''
     hardware_uri
   end
 

--- a/lib/chef/provisioning/oneview/oneview_api.rb
+++ b/lib/chef/provisioning/oneview/oneview_api.rb
@@ -83,7 +83,7 @@ module OneViewAPI
     raise 'No more blades are available for provisioning!' # Every bay is full and no more machines can be allocated
   end
 
-    def hardware_for_template_with_location(template, location)
+  def hardware_for_template_with_location(template, location)
     server_hardware_type_uri = template['serverHardwareTypeUri']
     enclosure_group_uri      = template['enclosureGroupUri']
     raise 'Template must specify a valid hardware type uri!' if server_hardware_type_uri.nil? || server_hardware_type_uri.empty?
@@ -115,7 +115,6 @@ module OneViewAPI
       end
     end
     false
-    puts ''
   end
 
   def wait_for_profile(action_handler, machine_spec,machine_options,  profile)
@@ -132,7 +131,6 @@ module OneViewAPI
       profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number']) # Refresh profile
       raise "Server profile state '#{profile['state']}' not 'Normal'" unless profile['state'] == 'Normal'
     end
-    puts ''
   end
 
 
@@ -174,7 +172,6 @@ module OneViewAPI
         raise "Powering #{state} machine #{machine_spec.name} failed!" unless task['taskState'].casecmp('completed') == 0
       end
     end
-    puts ''
     hardware_uri
   end
 

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -27,17 +27,17 @@ module Chef::Provisioning
     # Additional No-Op classes to nil return when a :converge is called
     # Returns a OneViewTransport::disconnect (nil)
     class OneViewTransport
-     def disconnect(*args, &block)
+     def disconnect(*_args, &_block)
       nil
      end
     end
 
    # Additional Converge class that nils the called methods under a :converge action
     class OneViewConvergence
-     def setup_convergence(*args, &block)
+     def setup_convergence(*_args, &_block)
       nil
      end
-     def converge(*args, &block)
+     def converge(*_args, &_block)
       nil
      end
     end
@@ -109,7 +109,7 @@ module Chef::Provisioning
       end
       
    
-   end
+    end
 
 
     def allocate_machine(action_handler, machine_spec, machine_options)
@@ -156,7 +156,7 @@ module Chef::Provisioning
         customize_machine(action_handler, machine_spec, machine_options, profile)
            #This is a provisining function and handles installing a chef-client
         machine_for(machine_spec, machine_options) # Return the Machine object 
-     end
+      end
     end
 
 
@@ -193,8 +193,7 @@ module Chef::Provisioning
         convergence_strategy = Chef::Provisioning::ConvergenceStrategy::InstallSh.new(
           machine_options[:convergence_options], {})
       Chef::Provisioning::Machine::UnixMachine.new(machine_spec, transport, convergence_strategy)
-  end
-
+    end
 
     def stop_machine(action_handler, machine_spec, _machine_options)
       power_off(action_handler, machine_spec) if machine_spec.reference
@@ -235,7 +234,7 @@ module Chef::Provisioning
                action_handler.report_progress "WARN: Failed to delete client #{name} from server!"
                puts "Error: #{e.message}"
              end
-          end
+            end
         end
 
         # Remove entry from known_hosts file(s)

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -95,16 +95,14 @@ module Chef::Provisioning
       if @icsp_base_url.nil?
         Chef::Log.warn('knife.rb is missing knife[:icsp_url]')
         @icsp_ignore = true
-      end
-
-      if @icsp_username.nil?
-        Chef::Log.warn('knife.rb is missing knife[:icsp_username]')
-        @icsp_ignore = true
-      end
-
-      if @icsp_password.nil?
-        Chef::Log.warn('knife.rb is missing knife[:icsp_password]')
-        @icsp_ignore = true
+        if @icsp_username.nil?
+          Chef::Log.warn('knife.rb is missing knife[:icsp_username]')
+          @icsp_ignore = true
+          if @icsp_password.nil?
+            Chef::Log.warn('knife.rb is missing knife[:icsp_password]')
+            @icsp_ignore = true
+          end
+        end
       end
 
       if @icsp_ignore == false

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -132,24 +132,6 @@ module Chef::Provisioning
       end
     end
 
-
-    def wait_for_profile(action_handler, machine_spec,machine_options,  profile)
-      # Wait for server profile to finish building
-      unless profile['state'] == 'Normal'
-        action_handler.perform_action "Wait for #{machine_spec.name} server to start and profile to be applied" do
-          action_handler.report_progress "INFO: Waiting for #{machine_spec.name} server to start and profile to be applied"
-          task = oneview_wait_for(profile['taskUri'], 360) # Wait up to 60 min for profile to be created
-          raise 'Timed out waiting for server to start and profile to be applied' if task == false
-          unless task == true
-            server_template = machine_options[:driver_options][:server_template]
-            raise "Error creating server profile from template #{server_template}: #{task['taskErrors'].first['message']}"
-          end
-        end
-        profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number']) # Refresh profile
-        raise "Server profile state '#{profile['state']}' not 'Normal'" unless profile['state'] == 'Normal'
-      end
-    end
-
     def ready_machine(action_handler, machine_spec, machine_options)
       profile = get_oneview_profile_by_sn(machine_spec.reference['serial_number'])
       raise "Failed to retrieve Server Profile for #{machine_spec.name}. Serial Number used to search: #{machine_spec.reference['serial_number']}" unless profile

--- a/lib/chef/provisioning/oneview_driver.rb
+++ b/lib/chef/provisioning/oneview_driver.rb
@@ -85,21 +85,30 @@ module Chef::Provisioning
 
       # Added newline to make reading of output easier
       puts ''
-
+      @icsp_ignore = false
       # Additional Checks to see if there is an ICSP server specified
       if @icsp_base_url.nil?
 	Chef::Log.warn("WARNING: Haven\'t set the knife[:icsp_url] in knife.rb!")
-        if @icsp_username.nil?
-	  Chef::Log.warn("WARNING: Haven\'t set the knife[:icsp_username] in knife.rb!")
-          if @icsp_password.nil?
-            Chef::Log.warn("WARNING: Haven\'t set the knife[:icsp_password] in knife.rb!")
-          else
+        @icsp_ignore = true
+      end
+      
+      if @icsp_username.nil?
+        Chef::Log.warn("WARNING: Haven\'t set the knife[:icsp_username] in knife.rb!")
+        @icsp_ignore = true
+      end
+      
+      if @icsp_password.nil?
+        Chef::Log.warn("WARNING: Haven\'t set the knife[:icsp_password] in knife.rb!")
+        @icsp_ignore = true 
+      end
+      
+      if @icsp_ignore == false
 	    Chef::Log.info("ICSP configuration complete, logging into ICSP") 
             @current_icsp_api_version = get_icsp_api_version
             @icsp_key            = login_to_icsp
-          end
-        end
-     end 
+      end
+      
+   
    end
 
 

--- a/lib/chef/provisioning/rest.rb
+++ b/lib/chef/provisioning/rest.rb
@@ -17,10 +17,11 @@ module RestAPI
       raise "Invalid rest host: #{host}"
     end
 
-    http = Net::HTTP.new(uri.host, uri.port)
+    http = Net::HTTP.new(uri.host, uri.port) 
+    http.read_timeout = @api_timeout #timeout for a request
+    http.open_timeout = @api_timeout #timeout for a connection
     http.use_ssl = true if uri.scheme == 'https'
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE if disable_ssl
-
     case type.downcase
     when 'get', :get
       request = Net::HTTP::Get.new(uri.request_uri)

--- a/lib/chef/provisioning/rest.rb
+++ b/lib/chef/provisioning/rest.rb
@@ -17,9 +17,9 @@ module RestAPI
       raise "Invalid rest host: #{host}"
     end
 
-    http = Net::HTTP.new(uri.host, uri.port) 
-    http.read_timeout = @api_timeout #timeout for a request
-    http.open_timeout = @api_timeout #timeout for a connection
+    http = Net::HTTP.new(uri.host, uri.port)
+    http.read_timeout = @api_timeout # timeout for a request
+    http.open_timeout = @api_timeout # timeout for a connection
     http.use_ssl = true if uri.scheme == 'https'
     http.verify_mode = OpenSSL::SSL::VERIFY_NONE if disable_ssl
     case type.downcase

--- a/spec/unit/oneview_driver_spec.rb
+++ b/spec/unit/oneview_driver_spec.rb
@@ -53,19 +53,5 @@ RSpec.describe Chef::Provisioning::OneViewDriver do
       expect { Chef::Provisioning::OneViewDriver.new(@canonical_url, knife_config) }.to raise_error('Must set the knife[:oneview_password] attribute!')
     end
 
-    it 'requires the icsp_url knife param' do
-      knife_config[:knife].delete(:icsp_url)
-      expect { Chef::Provisioning::OneViewDriver.new(@canonical_url, knife_config) }.to raise_error('Must set the knife[:icsp_url] attribute!')
-    end
-
-    it 'requires the icsp_username knife param' do
-      knife_config[:knife].delete(:icsp_username)
-      expect { Chef::Provisioning::OneViewDriver.new(@canonical_url, knife_config) }.to raise_error('Must set the knife[:icsp_username] attribute!')
-    end
-
-    it 'requires the icsp_password knife param' do
-      knife_config[:knife].delete(:icsp_password)
-      expect { Chef::Provisioning::OneViewDriver.new(@canonical_url, knife_config) }.to raise_error('Must set the knife[:icsp_password] attribute!')
-    end
   end
 end


### PR DESCRIPTION
Additional capabilities added:

Ability to use :allocate action to provision only a server profile (:converge will provision OS and install client).
Server location affinity, gives the ability to use a recipe to specify a particular server for a particular use case e.g. :server_location => 'enc1, bay1'
Insight Control Server Provisioning is no longer a requirement, Chef warnings will be generated for missing configuration and if :converge action is used however it will safely provision a server profile. This change allows the use of the HPE Data centre simulator
Added the ability to use a timeout in the knife.rb for connectivity (for debug/testing and network testing issues)
Additional error generation and logic dependant of actions added also.